### PR TITLE
add: install 1password-cli for secure password management

### DIFF
--- a/tasks/homebrew.yml
+++ b/tasks/homebrew.yml
@@ -69,6 +69,7 @@
     - 'gpg'                       # GNU Privacy Guard
     - 'gnupg'                     # GNU Privacy Guard (extended)
     - 'age'                       # Modern encryption tool
+    - '1password-cli'             # 1Password command line tool
     # === Compression & Archiving ===
     - 'xz'                        # XZ compression
     # === Automation & Scripting ===


### PR DESCRIPTION
## Summary
- Add 1password-cli to homebrew packages list for secure password management via CLI

## Test plan
- [ ] Run the ansible playbook to verify 1password-cli installs successfully
- [ ] Verify the package is placed in the correct section (Security & Encryption)

🤖 Generated with [Claude Code](https://claude.com/claude-code)