### PR TITLE
add: install t-rec for terminal recording

### DIFF
--- a/tasks/homebrew.yml
+++ b/tasks/homebrew.yml
@@ -89,6 +89,7 @@
     # - 'docker-completion'       # Docker shell completion
     # === Other Tools ===
     - 'toilet'                    # ASCII art text generator
+    - 't-rec'                     # Terminal recorder
     # - 'readline'                # Terminal library
     # - 'reattach-to-user-namespace'  # Tmux clipboard support
     # === Performance Analysis (for ISUCON) ===


### PR DESCRIPTION
## Summary
- Add t-rec (Terminal recorder) to homebrew package installation list

## Test plan
- [ ] Verify the package installation succeeds with `brew install t-rec`
- [ ] Confirm t-rec is properly added to the Other Tools section

🤖 Generated with [Claude Code](https://claude.com/claude-code)