### PR TITLE
add: specify tool and Claude Code configuration

### DIFF
--- a/.claude/commands/add-brew.md
+++ b/.claude/commands/add-brew.md
@@ -1,0 +1,16 @@
+---
+description: Add a new Homebrew package to tasks/homebrew.yml
+allowed-tools:
+  - Read
+  - Edit
+  - Bash(git:*)
+  - Bash(gh:*)
+---
+
+Use the add-homebrew-tool skill to add "$ARGUMENTS" to tasks/homebrew.yml.
+
+After adding the package:
+1. Create a git commit with a descriptive message
+2. Create a new branch if on master
+3. Push the branch and create a PR
+4. Enable auto-merge on the PR

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,38 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+This is an Ansible-based macOS infrastructure automation repository. It automates the setup of development environments including Homebrew packages, programming languages, and development tools.
+
+## Commands
+
+```shell
+# Dry-run to preview changes
+ansible-playbook localhost-mac.yml --diff --check
+
+# Execute the playbook
+ansible-playbook localhost-mac.yml
+```
+
+## Prerequisites
+
+- Homebrew must be installed first
+- Ansible installed via `brew install ansible`
+
+## Architecture
+
+The main playbook (`localhost-mac.yml`) orchestrates three task modules:
+
+1. **tasks/homebrew.yml** - Homebrew taps, formulae, and casks
+2. **tasks/langs.yml** - Language runtime installations (Rust, SDKMAN, pipx)
+3. **tasks/tools.yml** - Additional tools (Krew, SOPS, hishtory, git-worktree-runner, serena)
+
+Helper scripts live in `scripts/`.
+
+## Key Patterns
+
+- XDG Base Directory paths are used consistently (e.g., `$XDG_DATA_HOME/rustup`)
+- tmux is installed from HEAD due to a bug in the stable release
+- The playbook runs locally (`hosts: localhost`, `connection: local`)

--- a/tasks/homebrew.yml
+++ b/tasks/homebrew.yml
@@ -45,6 +45,8 @@
     - 'mise'                      # Polyglot runtime manager (asdf alternative)
     - 'delve'                     # Go debugger
     # - 'uv'                      # Python package installer (fast pip alternative)
+    # === API & Schema Tools ===
+    - 'specify'                   # OpenAPI specification CLI tool
     # === Text Processing & Data Tools ===
     - 'jq'                        # JSON processor
     - 'yq'                        # YAML/XML/TOML processor


### PR DESCRIPTION
## Summary
- Add `specify` (OpenAPI specification CLI) to homebrew packages
- Add `CLAUDE.md` for Claude Code guidance
- Add custom slash command `/add-brew` for adding homebrew packages

## Test plan
- [ ] Run `ansible-playbook localhost-mac.yml --diff --check` to verify syntax
- [ ] Verify specify installs correctly via `brew install specify`