### PR TITLE
add: install qlmarkdown for Markdown QuickLook preview

### DIFF
--- a/tasks/homebrew.yml
+++ b/tasks/homebrew.yml
@@ -114,5 +114,6 @@
     name: [
       'keyclu',
       'font-plemol-jp-nf',
+      'qlmarkdown',
     ]
     state: present


### PR DESCRIPTION
## Summary
- Add `qlmarkdown` cask to Homebrew packages for Markdown file QuickLook preview support

## Test plan
- [ ] Run `ansible-playbook localhost-mac.yml --diff --check` to verify the playbook
- [ ] Run `ansible-playbook localhost-mac.yml` to install the package
- [ ] Verify QuickLook preview works for `.md` files in Finder