### PR TITLE
add: rtk for LLM token reduction and remove serena

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ The main playbook (`localhost-mac.yml`) orchestrates three task modules:
 
 1. **tasks/homebrew.yml** - Homebrew taps, formulae, and casks
 2. **tasks/langs.yml** - Language runtime installations (Rust, SDKMAN, pipx)
-3. **tasks/tools.yml** - Additional tools (Krew, SOPS, hishtory, git-worktree-runner, serena)
+3. **tasks/tools.yml** - Additional tools (Krew, SOPS, hishtory, git-worktree-runner)
 
 Helper scripts live in `scripts/`.
 

--- a/tasks/homebrew.yml
+++ b/tasks/homebrew.yml
@@ -45,6 +45,8 @@
     - 'mise'                      # Polyglot runtime manager (asdf alternative)
     - 'delve'                     # Go debugger
     # - 'uv'                      # Python package installer (fast pip alternative)
+    # === AI & LLM Tools ===
+    - 'rtk'                       # CLI proxy to minimize LLM token consumption
     # === API & Schema Tools ===
     - 'specify'                   # OpenAPI specification CLI tool
     # === Text Processing & Data Tools ===

--- a/tasks/tools.yml
+++ b/tasks/tools.yml
@@ -94,12 +94,3 @@
         src: "{{ xdg_data_home }}/git-worktree-runner/bin/git-gtr"
         dest: "{{ lookup('env', 'HOME') }}/.local/bin/git-gtr"
         state: link
-
-- name: Install serena
-  block:
-    - name: Clone serena repository
-      git:
-        repo: https://github.com/oraios/serena.git
-        dest: "{{ lookup('env', 'HOME') }}/Workspace/app/serena"
-        version: main
-        update: yes


### PR DESCRIPTION
## Summary
- Add `rtk` (CLI proxy that minimizes LLM token consumption) under a new "AI & LLM Tools" section in `tasks/homebrew.yml`
- Remove the serena install block from `tasks/tools.yml` and drop its mention from `CLAUDE.md`

## Test plan
- [ ] `ansible-playbook localhost-mac.yml --diff --check` runs without errors
- [ ] `ansible-playbook localhost-mac.yml` installs `rtk` successfully
- [ ] No leftover references to serena in the repo