### PR TITLE
add: install shfmt for shell script formatting

### DIFF
--- a/tasks/homebrew.yml
+++ b/tasks/homebrew.yml
@@ -33,6 +33,7 @@
     # === Programming Language Tools ===
     - 'mise'                      # Polyglot runtime manager (asdf alternative)
     - 'delve'                     # Go debugger
+    - 'shfmt'                     # Shell script formatter
     # - 'uv'                      # Python package installer (fast pip alternative)
     # === AI & LLM Tools ===
     - 'rtk'                       # CLI proxy to minimize LLM token consumption


### PR DESCRIPTION
## Summary
- Add `shfmt` to Homebrew packages under Programming Language Tools

## Test plan
- [ ] Run `ansible-playbook localhost-mac.yml --diff --check`
- [ ] Run `ansible-playbook localhost-mac.yml`
- [ ] Verify `shfmt --version` works