### PR TITLE
add: install shellcheck for shell script static analysis

### DIFF
--- a/tasks/homebrew.yml
+++ b/tasks/homebrew.yml
@@ -34,6 +34,7 @@
     - 'mise'                      # Polyglot runtime manager (asdf alternative)
     - 'delve'                     # Go debugger
     - 'shfmt'                     # Shell script formatter
+    - 'shellcheck'                # Shell script static analyzer
     # - 'uv'                      # Python package installer (fast pip alternative)
     # === AI & LLM Tools ===
     - 'rtk'                       # CLI proxy to minimize LLM token consumption


### PR DESCRIPTION
## Summary
- Add `shellcheck` to Homebrew packages for static analysis of shell scripts, complementing the existing `shfmt` formatter.

## Test plan
- [ ] `ansible-playbook localhost-mac.yml --diff --check` shows shellcheck will be installed
- [ ] `ansible-playbook localhost-mac.yml` succeeds
- [ ] `shellcheck --version` works after run