### PR TITLE
add: install ffmpeg for audio/video processing

### DIFF
--- a/tasks/homebrew.yml
+++ b/tasks/homebrew.yml
@@ -82,6 +82,8 @@
     # - 'docker'                  # Container platform
     # - 'docker-compose'          # Multi-container Docker applications
     # - 'docker-completion'       # Docker shell completion
+    # === Media Processing ===
+    - 'ffmpeg'                    # Audio/video processing toolkit
     # === Other Tools ===
     - 'toilet'                    # ASCII art text generator
     - 't-rec'                     # Terminal recorder


### PR DESCRIPTION
## Summary
- Add ffmpeg to Homebrew packages under a new Media Processing section

## Test plan
- [ ] `ansible-playbook localhost-mac.yml --diff --check` shows ffmpeg as a pending install
- [ ] `ansible-playbook localhost-mac.yml` installs ffmpeg successfully
- [ ] `ffmpeg -version` runs after install