### PR TITLE
add: install duckdb for analytical SQL queries

### DIFF
--- a/tasks/homebrew.yml
+++ b/tasks/homebrew.yml
@@ -45,6 +45,7 @@
     - 'yq'                        # YAML/XML/TOML processor
     - 'xmlstarlet'                # XML processor
     - 'nkf'                       # Network Kanji Filter (encoding converter)
+    - 'duckdb'                    # In-process analytical SQL database
     # === Enhanced Unix Tools ===
     - 'bat'                       # cat with syntax highlighting
     - 'eza'                       # Modern ls replacement


### PR DESCRIPTION
## Summary
- Add `duckdb` to the Homebrew packages under Text Processing & Data Tools

## Test plan
- [ ] `ansible-playbook localhost-mac.yml --diff --check` shows duckdb install
- [ ] `ansible-playbook localhost-mac.yml` succeeds
- [ ] `duckdb --version` works after install